### PR TITLE
chore: set checksum behavior to update

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,3 +5,5 @@ nodeLinker: node-modules
 pnpFallbackMode: all
 
 yarnPath: .yarn/releases/yarn-3.2.1.cjs
+
+checksumBehavior: update


### PR DESCRIPTION
Updated yarn checksum behavior to use `update` – taken from [suggestions here](https://github.com/yarnpkg/berry/issues/1142)